### PR TITLE
update zt-zip library to version 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-zip</artifactId>
-            <version>1.7</version>
+            <version>1.13</version>
             <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
fixes zip-slip functionality: https://github.com/snyk/zip-slip-vulnerability